### PR TITLE
Remove navigation bar on the admin  dashboard page

### DIFF
--- a/app/index.pug
+++ b/app/index.pug
@@ -6,6 +6,6 @@ html
     main
       ui-view(class='main-view' ng-cloak)
         div(ngif="!isAdminState")
-        include shared-views/footer
+          include shared-views/footer
 
 

--- a/app/js/controllers/admin-dashboard.js
+++ b/app/js/controllers/admin-dashboard.js
@@ -1,7 +1,7 @@
 const AdminDashboardCtrl = function ($scope, $state, $mdDialog, $mdToast, AdminDataService, ClientDataService, $sce) {
 
     $scope.sectionTitle = '';
-
+    $scope.$parent.isAdminState = true;
     $scope.items = [];
 
     //utlility methods

--- a/app/sass/admin-dashboard.scss
+++ b/app/sass/admin-dashboard.scss
@@ -1,6 +1,7 @@
 .dashboard-view {
     height: 100%;
     display: flex;
+    margin-top: -100px;
     aside {
         flex-basis: 15%;
         background: #323544;

--- a/app/sass/app.scss
+++ b/app/sass/app.scss
@@ -70,6 +70,7 @@ p {
 
 main {
     position: relative;
+    top: 100px;
 }
 
 md-dialog {

--- a/app/sass/app.scss
+++ b/app/sass/app.scss
@@ -70,7 +70,6 @@ p {
 
 main {
     position: relative;
-    top: 100px;
 }
 
 md-dialog {


### PR DESCRIPTION
#### What does this PR do?
This PR removes the navigation bar from  the admin/dashboard page.


#### How should this be manually tested?
`git checkout remove-navbar-footer-on-admin`
run `gulp`
navigate to the `admin/dashboard` page
