### PR TITLE
Bug fix for projects api endpoint

### DIFF
--- a/app/views/projects.pug
+++ b/app/views/projects.pug
@@ -8,13 +8,16 @@
     section
       .projects-container
         h2 2008 - 2010
-        p(ng-repeat='project in earlyProjects') {{project.name}}
+        p(ng-repeat='project in earlyProjects') 
+          a(ui-sref="project({id: project._id})") {{project.name}}
       .projects-container
         h2 2011 - 2014
-        p(ng-repeat='project in midProjects') {{project.name}}
+        p(ng-repeat='project in midProjects')
+          a(ui-sref="project({id: project._id})") {{project.name}}
       .projects-container
         h2 2015 - 2017
-        p(ng-repeat='project in lateProjects') {{project.name}}
+        p(ng-repeat='project in lateProjects')
+          a(ui-sref="project({id: project._id})") {{project.name}}
 
 
 

--- a/server/controllers/projects.js
+++ b/server/controllers/projects.js
@@ -5,8 +5,9 @@ const Project = require('../models/projects'),
 
 module.exports = {
     getAllProjects: (req, res) => {
+        let search_str = req.query.search || '';
         let projectsFilter = {
-            name: new RegExp('^.*('+req.query.search +').*$', 'i'),
+            name: new RegExp('^.*('+search_str +').*$', 'i'),
             isFeaturedProject: req.query.featured || false
         }
         Project.find(projectsFilter, (err, projects) => {


### PR DESCRIPTION
The endpoint for projects would return blank if the search query parameter was not provided vs returning a list of all projects.

Also linked the projects list on the projects page to their individual project page

Tested the fix locally and the projects page now works
![screen shot 2017-11-24 at 15 12 00](https://user-images.githubusercontent.com/1008418/33210096-e0048ac0-d129-11e7-887a-e0da00e20cb3.png)
