### PR TITLE
Admin crud services

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -24,6 +24,7 @@ import AdminProcessCtrl from './controllers/admin/process';
 import AdminTestimonialCtrl from './controllers/admin/testimonial';
 import AdminWhyNijelCtrl from './controllers/admin/why-nijel';
 import AdminTeamCtrl from './controllers/admin/team';
+import AdminServiceCtrl from './controllers/admin/services';
 
 // import services
 import ClientDataService from './services/ClientDataService';
@@ -46,6 +47,7 @@ nijelApp.controller('TeamCtrl', TeamCtrl)
     .controller('AdminTestimonialCtrl', AdminTestimonialCtrl)
     .controller('AdminWhyNijelCtrl', AdminWhyNijelCtrl)
     .controller('AdminTeamCtrl', AdminTeamCtrl)
+    .controller('AdminServiceCtrl', AdminServiceCtrl)
     .controller('AdminDashboardCtrl', AdminDashboardCtrl)
     .factory('ClientDataService', ClientDataService)
     .factory('AdminDataService', AdminDataService);
@@ -141,6 +143,11 @@ nijelApp.config(['$stateProvider', '$httpProvider',
                 url: '/testimonials',
                 controller: 'AdminTestimonialCtrl',
                 templateUrl: 'views/admin/testimonials.html',
+            })
+            .state('admin.dashboard.services', {
+                url: '/services',
+                controller: 'AdminServiceCtrl',
+                templateUrl: 'views/admin/services.html',
             });
 
         $locationProvider.html5Mode(true);

--- a/app/js/controllers/admin/services.js
+++ b/app/js/controllers/admin/services.js
@@ -1,5 +1,105 @@
 const AdminServiceCtrl = function ($scope, $state, $mdDialog, $mdToast, AdminDataService, ClientDataService, $sce) {
+    
+    getServices();
+    //utlility methods
+    $scope.trustAsHtml = (template) => {
+        return $sce.trustAsHtml(template);
+    };
 
+    function getServices() {
+        ClientDataService.fetchServices()
+            .then((resp) => {
+                $scope.services = resp.data.services;
+            }, (err) => {
+                console.error(err, 'ERROR');
+            });
+        
+    }
+
+    $scope.updateService = (event, service) => {
+        $mdDialog.show({
+            locals: {
+                dataToPass: service
+            },
+            controller: updateServiceDialogController,
+            templateUrl: 'views/admin/update-service-dialog.html',
+            parent: angular.element(document.body),
+            clickOutsideToClose: true,
+        });
+    };
+
+    $scope.deleteService = (ev, service, $index, $mdToast) => {
+        let confirm = $mdDialog.confirm()
+            .title('Are you sure, you want to delete this item ?')
+            .textContent('Clicking on YES, will delete this item permanently!')
+            .targetEvent(ev)
+            .ok('YES')
+            .cancel('NO');
+        $mdDialog.show(confirm).then(() => {
+            AdminDataService.deleteService(service)
+                .then((resp) => {
+                    if (resp.data.success) {
+                        $scope.services.forEach((elem, $index) => {
+                            if (elem._id === service._id) {
+                                $scope.services.splice($index, 1);
+                            }
+                        });
+                    }
+                }, (err) => {
+                    console.error(err, 'ERR');
+                });
+        }, () => {
+        });
+    };
+
+    function addServiceDialogController($scope, $mdDialog, $mdToast) {
+        $scope.createNewService = () => {
+            AdminDataService.createNewService($scope.service)
+                .then((resp) => {
+                    $mdDialog.hide();
+                    $mdToast.show(
+                        $mdToast.simple()
+                            .textContent(resp.data.message)
+                            .hideDelay(3000)
+                    );
+                    getServices();
+                }, (err) => {
+                    console.error(err, 'ERROR');
+                });
+        };
+    }
+
+    function updateServiceDialogController($scope, $mdDialog, $mdToast, dataToPass) {
+        $scope.service = dataToPass;
+
+        $scope.updateService = () => {
+            AdminDataService.updateService($scope.service)
+                .then((res) => {
+                    $mdDialog.hide();
+                    $mdToast.show(
+                        $mdToast.simple()
+                            .textContent('Service successfully updated!')
+                            .hideDelay(3000)
+                    );
+                }, (err) => {
+                    $mdDialog.hide();
+                    $mdToast.show(
+                        $mdToast.simple()
+                            .textContent('Service not updated!')
+                            .hideDelay(3000)
+                    );
+                });
+        };
+    }
+
+    $scope.launchAddServiceModal = (env) => {
+        $mdDialog.show({
+            controller:addServiceDialogController,
+            templateUrl: 'views/admin/add-service-dialog.html',
+            parent: angular.element(document.body),
+            clickOutsideToClose: true,
+        });
+    };
 }
 
 export default AdminServiceCtrl;

--- a/app/js/controllers/admin/services.js
+++ b/app/js/controllers/admin/services.js
@@ -1,0 +1,5 @@
+const AdminServiceCtrl = function ($scope, $state, $mdDialog, $mdToast, AdminDataService, ClientDataService, $sce) {
+
+}
+
+export default AdminServiceCtrl;

--- a/app/js/services/AdminDataService.js
+++ b/app/js/services/AdminDataService.js
@@ -24,6 +24,9 @@ const AdminDataService = function ($http, $q)  {
         createNewProcessSection(section) {
             return $http.post('/api/processes', section);
         },
+        createNewService(service) {
+            return $http.post('/api/services', service);
+        },
         deleteTestimonial(testimonial) {
             return $http.delete(('/api/testimonials/' + testimonial._id));
         },
@@ -39,6 +42,9 @@ const AdminDataService = function ($http, $q)  {
         deleteTeamMember(teamMember) {
             return $http.delete(('/api/team/' + teamMember._id));
         },
+        deleteService(service) {
+            return $http.delete(('/api/services/' + service._id));
+        },
         updateTestimonial(testimonial) {
             return $http.put(('/api/testimonials/' + testimonial._id), testimonial);
         },
@@ -53,6 +59,9 @@ const AdminDataService = function ($http, $q)  {
         },
         updateProcessSection(section) {
             return $http.put(('/api/processes/' + section._id), section);
+        },
+        updateService(service) {
+            return $http.put(('/api/services/' + service._id), service);
         }
     };
 };

--- a/app/js/services/ClientDataService.js
+++ b/app/js/services/ClientDataService.js
@@ -55,6 +55,13 @@ const ClientDataService = function ($http, $q) {
                 url: '/api/processes'
             });
         },
+
+        fetchServices: () => {
+            return $http({
+                method: 'GET',
+                url: '/api/services'
+            });
+        },
     };
 };
 

--- a/app/views/admin/add-service-dialog.pug
+++ b/app/views/admin/add-service-dialog.pug
@@ -1,0 +1,6 @@
+.dialog-view
+    h2 Add New Service
+    form(ng-submit='createNewService()')
+        input(type='text' placeholder='Title' ng-model='service.title' required)
+        ng-quill-editor(ng-model='service.description', name='description')
+        input(type='submit')

--- a/app/views/admin/dashboard.pug
+++ b/app/views/admin/dashboard.pug
@@ -9,5 +9,6 @@
       button(ui-sref='admin.dashboard.team') Team
       button(ui-sref='admin.dashboard.why-nijel') Why NiJeL
       button(ui-sref='admin.dashboard.processes') Processes
+      button(ui-sref='admin.dashboard.services') Services
   section
     div.ui-view

--- a/app/views/admin/services.pug
+++ b/app/views/admin/services.pug
@@ -1,2 +1,26 @@
-md-button.md-fab(aria-label='Add Service', class='md-fab-bottom-right launchItemModal', ng-click='launchAddProcessSectionModal($event)', style="position:fixed !important;")
+md-button.md-fab(aria-label='Add Service', class='md-fab-bottom-right launchItemModal', ng-click='launchAddServiceModal($event)', style="position:fixed !important;")
     md-icon.material-icons add
+
+md-card
+    md-toolbar.md-table-toolbar.md-default
+        .md-toolbar-tools
+            h2.md-title Services              
+            .flex(flex='')
+    md-table-container
+        table(md-table=''   md-progress='promise')
+            thead(md-head='')
+                tr(md-row='')
+                    th(md-column='') Title
+                    th(md-column='') Description
+                    th(md-column='') Actions
+            tbody(md-body='')
+                tr(md-row=''  md-select-id='name'  ng-repeat='service in services')
+                    td(md-cell='')
+                        a(md-cell='') {{service.title}}
+                    td(md-cell='' ng-bind-html="trustAsHtml(service.description)")
+                    td(md-cell='')
+                        div(layout='row', layout-sm='column',)
+                            md-button.md-icon-button.md-accent(aria-label='Edit', ng-click='updateService($event, service)')
+                                md-icon.material-icons edit
+                            md-button.md-icon-button.md-accent(aria-label='Delete', ng-click='deleteService($event, service)')
+                                md-icon.material-icons delete

--- a/app/views/admin/services.pug
+++ b/app/views/admin/services.pug
@@ -1,0 +1,2 @@
+md-button.md-fab(aria-label='Add Service', class='md-fab-bottom-right launchItemModal', ng-click='launchAddProcessSectionModal($event)', style="position:fixed !important;")
+    md-icon.material-icons add

--- a/app/views/admin/update-service-dialog.pug
+++ b/app/views/admin/update-service-dialog.pug
@@ -1,0 +1,6 @@
+.dialog-view
+    h2 Update Service
+    form(ng-submit='updateService()')
+        input(type='text' placeholder='Title' ng-model='service.title' required)
+        ng-quill-editor(ng-model='service.description', name='description')
+        input(type='submit')

--- a/server/controllers/services.js
+++ b/server/controllers/services.js
@@ -1,0 +1,73 @@
+'use strict';
+const Service = require('../models/services');
+
+module.exports = {
+    getAllServices: (req, res) => {
+        Service.find((err, services) => {
+            if (err) {
+                res.send(err);
+            } else {
+                res.json({
+                    success: true,
+                    services: services
+                });
+            }
+        });
+    },
+    addService: (req, res) => {
+        let service = new Service();
+        service.title = req.body.title;
+        service.description = req.body.description;
+        service.save((err) => {
+            if (err) {
+                res.send(err);
+            } else {
+                res.json({
+                    success: true,
+                    message: 'Service successfully added',
+                    service: service
+
+                });
+            }
+        });
+    },
+    updateService: (req, res) => {
+        Service.findById(req.params.serviceId, (err, service) => {
+            if (!err) {
+                if (req.body.title) {
+                    service.title = req.body.title;
+                }
+                if (req.body.description) {
+                    service.description = req.body.description;
+                }
+
+                service.save((err) => {
+                    if (err) {
+                        res.send(err);
+                    }
+                    res.json({
+                        success: true,
+                        message: 'Service successfully updated'
+                    });
+                });
+            } else {
+                res.send(err);
+            }
+        });
+
+    },
+    deleteService: (req, res) => {
+        Service.remove({
+            _id: req.params.serviceId
+        }, (err) => {
+            if (err) {
+                res.send(err);
+            } else {
+                res.json({
+                    success: true,
+                    message: 'Service successfully deleted'
+                });
+            }
+        });
+    }
+};

--- a/server/models/services.js
+++ b/server/models/services.js
@@ -1,0 +1,14 @@
+const mongoose = require ('mongoose'),
+    Schema = mongoose.Schema,
+    ServicesSchema = new Schema({
+        title: {
+            type: String,
+            required: true
+        },
+        description: {
+            type: String,
+            required: true
+        },
+    });
+
+module.exports = mongoose.model('Services', ServicesSchema);

--- a/server/routes/authenticated.js
+++ b/server/routes/authenticated.js
@@ -6,6 +6,7 @@ const apiRouter = require('../apiRouter'),
     teamCtrl = require('../controllers/team'),
     whyNijelCtrl = require('../controllers/why-nijel'),
     processesCtrl = require('../controllers/processes'),
+    servicesCtrl = require('../controllers/services'),
     multer = require('multer'),
     upload = multer({
         dest: './uploads/'
@@ -36,12 +37,21 @@ module.exports = () => {
     apiRouter.route('/whynijel')
         .post(upload.single('photo'), whyNijelCtrl.addWhyNijelSection);
 
-    apiRouter.route('/whynijel/:sectionId') .put(upload.single('photo'), whyNijelCtrl.updateWhyNijelSection)
+    apiRouter.route('/whynijel/:sectionId') 
+        .put(upload.single('photo'), whyNijelCtrl.updateWhyNijelSection)
         .delete(whyNijelCtrl.deleteWhyNijelSection);
 
     apiRouter.route('/processes')
         .post(upload.single('photo'), processesCtrl.addProcessSection);
 
-    apiRouter.route('/processes/:sectionId').put(upload.single('photo'), processesCtrl.updateProcessSection)
+    apiRouter.route('/processes/:sectionId')
+        .put(upload.single('photo'), processesCtrl.updateProcessSection)
         .delete(processesCtrl.deleteProcessSection);
+    
+    apiRouter.route('/services')
+        .post(servicesCtrl.addService);
+
+    apiRouter.route('/services/:serviceId')
+        .put(servicesCtrl.updateService)
+        .delete(servicesCtrl.deleteService);
 };

--- a/server/routes/public.js
+++ b/server/routes/public.js
@@ -8,6 +8,7 @@ const apiRouter = require('../apiRouter'),
     processesCtrl = require('../controllers/processes'),
     nijelTweets = require('../controllers/nijel_tweets'),
     userCtrl = require('../controllers/user');
+    servicesCtrl = require('../controllers/services');
 
 module.exports = () => {
     apiRouter.route('/nijel-tweets')
@@ -36,4 +37,6 @@ module.exports = () => {
     
     apiRouter.route('/processes')
         .get(processesCtrl.getAllProcessesSections);
+    apiRouter.route('/services')
+        .get(servicesCtrl.getAllServices);
 };

--- a/server/routes/public.js
+++ b/server/routes/public.js
@@ -7,7 +7,7 @@ const apiRouter = require('../apiRouter'),
     whyNijelCtrl = require('../controllers/why-nijel'),
     processesCtrl = require('../controllers/processes'),
     nijelTweets = require('../controllers/nijel_tweets'),
-    userCtrl = require('../controllers/user');
+    userCtrl = require('../controllers/user'),
     servicesCtrl = require('../controllers/services');
 
 module.exports = () => {


### PR DESCRIPTION
#### What does this PR do?
Add missing page view for normal page content i.e services
#### Description of Task to be completed?

- Implement the crud functionality on the services section
- Have the  endpoints working:
      `GET api/services`
       `POST api/services`
       `PUT api/services:service_id`
       `DELETE api/services:service_id`
- Add the services section on the admin dashboard page where admins can view, add, update and delete services.

#### How should this be manually tested?
`git checkout to admin-crud-processes`
 run` gulp`
 Go to  `localhost:3000/admin/authenticate` and login
 At the dashboard go to the services section, Add , edit or update a service

#### Screenshot
<img width="1440" alt="screen shot 2017-11-30 at 2 23 57 am" src="https://user-images.githubusercontent.com/23323254/33404544-bfcb1cf6-d575-11e7-9280-b0c72f452bc5.png">
