### PR TITLE
highlight the various hashtags and accounts with links to them

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -4,6 +4,7 @@ import angularAria from 'angular-aria';
 import ngMaterial from 'angular-material';
 import ngFileUpload from 'ng-file-upload';
 import ngQuill from 'ng-quill';
+import ngSanitize from 'angular-sanitize';
 import angular from 'angular';
 import slugify from  './filters/slugify';
 import $ from 'jquery';
@@ -33,7 +34,7 @@ import ClientDataService from './services/ClientDataService';
 import AdminDataService from './services/AdminDataService';
 
 
-const nijelApp = angular.module('nijelApp', [uiRouter, angularAria, angularAnimate, ngMaterial, ngFileUpload, ngQuill, require('angular-material-data-table'), satellizer]);
+const nijelApp = angular.module('nijelApp', [uiRouter, angularAria, angularAnimate, ngMaterial, ngFileUpload, ngQuill, ngSanitize, require('angular-material-data-table'), satellizer]);
 
 nijelApp.filter('slugify', [slugify]);
 nijelApp.controller('TeamCtrl', TeamCtrl)

--- a/app/js/controllers/home.js
+++ b/app/js/controllers/home.js
@@ -5,9 +5,12 @@ import $ from 'jquery';
 const HomeCtrl = function($scope, ClientDataService, $document, $sce) {
 
     $scope.isAdminState = false;
-    $scope.tweetAsHtml = (text) => {
+    $scope.targetAttr = "";
+    $scope.trustAsHtml = (text) => {
         return $sce.trustAsHtml(text);
     }
+
+
     let testimonialIndex;
     $scope.tweets = [];
 
@@ -45,9 +48,10 @@ const HomeCtrl = function($scope, ClientDataService, $document, $sce) {
             if (resp.data.success) {
                 JSON.parse(resp.data.tweets).forEach((tweet, index) => {
                     tweet.created_at = moment(tweet.created_at).format("MMM Do");
+                     // replace #hashtags and @mentions
+                    tweet.text = tweet.text.replace( /(^|\s)#(\w*[a-zA-Z_]+\w*)/gim, '$1<a href="https://twitter.com/search?q=%23$2"' + $scope.targetAttr + ' target="_blank">#$2</a>').
+                                replace(/(^|\s)\@(\w*[a-zA-Z_]+\w*)/gim, '$1<a href="https://twitter.com/$2"' + $scope.targetAttr + 'target="_blank" >@$2</a>');
 
-                    tweet.text = tweet.text.replace(/(@[^ ]+)/g, '<a class="user">$1</a>').
-                              replace(/(#[^ ]+)/g, '<span class="hash">$1</span>');
                     $scope.tweets.push(tweet);
                 });
             }

--- a/app/js/controllers/home.js
+++ b/app/js/controllers/home.js
@@ -2,10 +2,12 @@ import moment from 'moment';
 import $ from 'jquery';
 
 
-const HomeCtrl = function($scope, ClientDataService, $document) {
+const HomeCtrl = function($scope, ClientDataService, $document, $sce) {
 
     $scope.isAdminState = false;
-
+    $scope.tweetAsHtml = (text) => {
+        return $sce.trustAsHtml(text);
+    }
     let testimonialIndex;
     $scope.tweets = [];
 
@@ -43,6 +45,9 @@ const HomeCtrl = function($scope, ClientDataService, $document) {
             if (resp.data.success) {
                 JSON.parse(resp.data.tweets).forEach((tweet, index) => {
                     tweet.created_at = moment(tweet.created_at).format("MMM Do");
+
+                    tweet.text = tweet.text.replace(/(@[^ ]+)/g, '<a class="user">$1</a>').
+                              replace(/(#[^ ]+)/g, '<span class="hash">$1</span>');
                     $scope.tweets.push(tweet);
                 });
             }

--- a/app/sass/home.scss
+++ b/app/sass/home.scss
@@ -214,6 +214,9 @@
         a {
             color: #1DA1F2;
         }
+        span {
+            color: #F26648;
+        }
     }
 }
 

--- a/app/views/home.pug
+++ b/app/views/home.pug
@@ -64,6 +64,6 @@
         img(src='assets/twitter-icon.png')
       .tweet
         .content
-          p(ng-bind-html='tweetAsHtml(tweet.text)')
+          p(ng-bind-html="trustAsHtml(tweet.text)")
         .date-posted
           p {{tweet.created_at}}

--- a/app/views/home.pug
+++ b/app/views/home.pug
@@ -64,6 +64,6 @@
         img(src='assets/twitter-icon.png')
       .tweet
         .content
-          p {{tweet.text}}
+          p(ng-bind-html='tweetAsHtml(tweet.text)')
         .date-posted
           p {{tweet.created_at}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,11 @@
       "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.6.6.tgz",
       "integrity": "sha1-qbs/xflx10XNOjvbqrxvH03rE/M="
     },
+    "angular-sanitize": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.6.7.tgz",
+      "integrity": "sha1-Wj1hrXuLaZkjMpY12ZJIvPziZAg="
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -5880,7 +5885,11 @@
       "requires": {
         "hoek": "2.16.3",
         "isemail": "1.2.0",
+<<<<<<< HEAD
         "moment": "2.19.4",
+=======
+        "moment": "2.20.1",
+>>>>>>> add ng-sanitize
         "topo": "1.1.0"
       }
     },
@@ -6809,9 +6818,9 @@
       }
     },
     "moment": {
-      "version": "2.19.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.4.tgz",
-      "integrity": "sha512-1xFTAknSLfc47DIxHDUbnJWC+UwgWxATmymaxIPQpmMh7LBm7ZbwVEsuushqwL2GYZU0jie4xO+TK44hJPjNSQ=="
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
     "mongodb": {
       "version": "2.2.33",
@@ -6833,9 +6842,15 @@
       }
     },
     "mongoose": {
+<<<<<<< HEAD
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.13.6.tgz",
       "integrity": "sha512-H+loD0D8UCwGmbOzWV7rZAf6/efRr9CPGB1Bess/IIjiWvpRQNo4zH4UHkueKoEbMWdnSYenjdEL8A0Q8p7JXg==",
+=======
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.13.7.tgz",
+      "integrity": "sha512-3VPcGQWaTzT/OVK+TpE9dGpNHBnEqFX2RmbFr1XvbsKmxPsL9kaRBSHqaQ8QEMd6CUeOYMRdH1pKRrlnCenRsg==",
+>>>>>>> add ng-sanitize
       "requires": {
         "async": "2.1.4",
         "bson": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "angular-material-data-table": "^0.10.10",
     "angular-messages": "^1.6.6",
     "auth0-js": "^8.12.0",
+    "angular-sanitize": "^1.6.7",
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "^1.17.2",
     "cloudinary": "^1.9.0",


### PR DESCRIPTION
#### What does this PR do?
Limit Twitter feed to only show Tweets tweeted from Nijel account and Retweets. Plus highlight the various hashtags and accounts with links to them

#### Description of Task to be completed?

- Limit Twitter feed to only show Tweets tweeted from Nijel account and Retweets. 
- highlight the various hashtags and accounts with links to them

#### How should this be manually tested?
git checkout to `highlight-mention-hashtags-twitter`
run `npm install`
 run` gulp`
 Go to  `localhost:3000` 
Scroll to the twitter feed section

#### Screenshot
<img width="960" alt="screen shot 2017-12-19 at 8 55 10 pm" src="https://user-images.githubusercontent.com/23323254/34171329-05ea9b56-e4ff-11e7-8287-dcccd2967568.png">
