### PR TITLE
Bug fix to remove bbase url to allow app to run on subdomain

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -90,7 +90,6 @@ nijelApp.config(['$stateProvider', '$httpProvider',
         $mdThemingProvider.theme('default')
             .primaryPalette('teal')
             .accentPalette('pink');
-        $authProvider.baseUrl = 'http://localhost:3000';
         $authProvider.google({
             clientId: '261811817799-7v2f4or792sv94rl8rjrn85e853334st.apps.googleusercontent.com',
             redirectUri: window.location.origin + '/admin/dashboard',


### PR DESCRIPTION
There was bug with deploying the application to any other domain that is not localhost because of a hardcoded configuration in the satellizer init. This PR removes that hardcoded localhost URL.

Tested on the live dev server and google login now works