### PR TITLE
Bug fix for Authorization Error

### DIFF
--- a/server/middleware/authValidator.js
+++ b/server/middleware/authValidator.js
@@ -1,11 +1,11 @@
-
+const jwt = require('jwt-simple'),
+    moment = require('moment');
 module.exports = {
     ensureAuthenticated: function(req, res, next){
         if (!req.header('Authorization')) {
             return res.status(401).send({ message: 'Please make sure your request has an Authorization header' });
         }
         var token = req.header('Authorization').split(' ')[1];
-
         var payload = null;
         try {
             payload = jwt.decode(token, process.env.SUPERSECRET);


### PR DESCRIPTION
We were missing two library imports that were causing the auth validator to fail. This PR includes those libraries in the authValidator module to fix the bug.

Tested locally and adding content in the backend now works