### PR TITLE
Remove top marging from h1 element

### DIFF
--- a/app/sass/app.scss
+++ b/app/sass/app.scss
@@ -82,6 +82,9 @@ body {
 p {
     margin-bottom: 20px;
 }
+h1 {
+    margin-top: 0;
+}
 
 .center-child-horizontal {
     display: flex;


### PR DESCRIPTION
 The margin on h1 element introduced by normalize.css is causing the main nav to be off on the team page. This style change fixes the issue.